### PR TITLE
Add public notes feature

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -19,7 +19,8 @@
   <!-- ★ 追加：ヘッダ右端リンク -->
     <nav class="header-links d-flex flex-column flex-md-row gap-2 justify-content-center justify-content-md-end">
     <a href="/tickets" class="btn btn-outline-light btn-md me-2">チケット</a>
-    <a href="/access"  class="btn btn-outline-light btn-md">アクセス</a>
+    <a href="/access"  class="btn btn-outline-light btn-md me-2">アクセス</a>
+    <a href="/public" class="btn btn-outline-light btn-md">みんなのリスト</a>
     </nav>
     
   <p class="welcome-msg text-white position-absolute start-0 bottom-0 ms-3 mb-2">

--- a/templates/public.html
+++ b/templates/public.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <title>みんなの行きたいところリスト</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&family=Poppins:wght@600&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body class="bg-light">
+<div class="title-band container-fluid text-center px-0 position-relative">
+  <h1 class="my-0 mx-5">みんなの行きたいところリスト</h1>
+  <nav class="header-links d-flex flex-column flex-md-row gap-2 justify-content-center justify-content-md-end">
+    <a href="/" class="btn btn-outline-light btn-md">マイリストへ戻る</a>
+  </nav>
+</div>
+
+<div class="container py-5">
+  <div class="btn-group btn-group-sm mb-3 w-100" id="filterGroup" role="group">
+    <button type="button" class="btn btn-outline-secondary active" data-cat="all">すべて</button>
+    <button type="button" class="btn btn-outline-secondary" data-cat="食事"><i class="bi bi-cup-hot me-1"></i>食事</button>
+    <button type="button" class="btn btn-outline-secondary" data-cat="観光地"><i class="bi bi-suitcase me-1"></i>観光地</button>
+    <button type="button" class="btn btn-outline-secondary" data-cat="パビリオン"><i class="bi bi-bank me-1"></i>パビリオン</button>
+    <button type="button" class="btn btn-outline-secondary" data-cat="その他">その他</button>
+  </div>
+
+  <div class="table-responsive">
+    <table class="table table-striped align-middle shadow-sm rounded-3 overflow-hidden mb-5" id="noteTable">
+      <thead class="table-light">
+        <tr>
+          <th style="width:30px;" class="text-center"></th>
+          <th style="width:80px;">タイトル</th>
+          <th style="width:110px;">内容</th>
+          <th style="width:110px;">記入者</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+const tbody = document.querySelector('#noteTable tbody');
+const filterGroup = document.getElementById('filterGroup');
+let currentFilter = 'all';
+
+async function api(path) {
+  const res = await fetch(path);
+  if(!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+let cacheNotes = [];
+const catIcons = {
+  '食事': '<i class="bi bi-cup-hot me-1"></i>',
+  '観光地': '<i class="bi bi-suitcase me-1"></i>',
+  'パビリオン': '<i class="bi bi-bank me-1"></i>',
+  'その他': '<span class="cat-icon" title="その他">&#x1f7e3;</span>'
+};
+
+function render(){
+  tbody.innerHTML='';
+  const notes = (currentFilter==='all') ? cacheNotes : cacheNotes.filter(n => n.category === currentFilter);
+  notes.forEach(n => {
+    const tr=document.createElement('tr');
+    tr.innerHTML=`
+      <td class="text-center">${catIcons[n.category] || ''}</td>
+      <td>${n.title}</td>
+      <td>${n.description}</td>
+      <td>${n.author}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+async function refresh(){
+  cacheNotes = await api('/api/all_notes');
+  render();
+}
+window.addEventListener('DOMContentLoaded', refresh);
+
+filterGroup.addEventListener('click', e=>{
+  const btn=e.target.closest('button[data-cat]');
+  if(!btn) return;
+  [...filterGroup.children].forEach(b=>b.classList.remove('active'));
+  btn.classList.add('active');
+  currentFilter = btn.dataset.cat;
+  render();
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add endpoint `/api/all_notes` and `/public` page to show all notes
- link to the new page from index
- add `public.html` template for viewing everyone's notes
- extend tests for new endpoint and update auth tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6848494329f4832e8e81562fd04dc5aa