### PR TITLE
Update mobile header style

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -65,8 +65,13 @@ h1, h2, h3     { font-family: 'Poppins', sans-serif;      }
    スマホ幅（<576px）でのレイアウト調整
 ------------------------------------------------- */
 @media (max-width:575.98px){
+  .title-band{
+    justify-content:flex-start;      /* タイトルを左寄せに */
+  }
   .title-band h1{
-    font-size:1.3rem;         /* タイトルをやや小さく */
+    font-size:1.6rem;                /* タイトルを大きく */
+    margin-left:1rem;                /* 少し左寄せ */
+    margin-right:1rem;               /* 余白を調整 */
   }
   .header-links{
     position:static;          /* 通常フローに戻す */


### PR DESCRIPTION
## Summary
- adjust header to left align on mobile
- enlarge header font for small screens

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684960b641b0832ebe514f8a48f6b6ba